### PR TITLE
Added event and challenge assets to docs

### DIFF
--- a/assets.md
+++ b/assets.md
@@ -95,6 +95,7 @@ Some event assets aren't exported on raw.communitydragon.org. These event assets
  - [Buff/debuf icons](http://raw.communitydragon.org/latest/game/data/spells/icons2d/)
  - [In-game cursors](http://raw.communitydragon.org/pbe/game/assets/ux/cursors/) (also [Qiyana's ones](http://raw.communitydragon.org/pbe/game/assets/characters/qiyana/cursors/))
  - [Mastery icons](https://raw.communitydragon.org/latest/game/assets/ux/mastery/)
+ - [Challenge assets](https://raw.communitydragon.org/latest/plugins/rcp-fe-lol-static-assets/global/default/images/challenges-shared/) like crystal and category icons
 
 ## Teamfight Tactics (TFT)
 

--- a/assets.md
+++ b/assets.md
@@ -65,6 +65,9 @@ the actual path, always check the champion's JSON file from
    also include limited edition borders ([example](https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/assets/characters/riven/skins/skin16/rivenloadscreen_16_le.jpg))
  - Spell icons (all forms): `game/assets/characters/{name}/hud/icons2d` ([example](https://raw.communitydragon.org/latest/game/assets/characters/khazix/hud/icons2d/))
 
+## Event assets
+Some event assets aren't exported on raw.communitydragon.org. These event assets (like images and videos) are sorted by year and event on [universe.communitydragon.org](https://universe.communitydragon.org)
+
 ## Other assets
 
  - [Summoner icons](https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/profile-icons/)
@@ -106,4 +109,3 @@ the actual path, always check the champion's JSON file from
 
  - [Old league tier images](https://raw.communitydragon.org/8.23/plugins/rcp-fe-lol-league-tier-names/global/default/assets/images/ranked-crests/)
  - [Old tier promotion animations](https://raw.communitydragon.org/8.23/plugins/rcp-fe-lol-leagues/global/default/videos/)
-


### PR DESCRIPTION
This PR adds another section to the Assets.md file that contains information about event assets. 
It also adds challenge assets like the crystals (bronze, diamond, ...), the backgrounds and the category icons (expertise and so on...). 

I would also like to add [this](https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/) folder to the documentation as it contains a lot of important data, but I can't find a suitable place for it.